### PR TITLE
Feature/event management

### DIFF
--- a/app/Modules/Events/Controllers/EventController.php
+++ b/app/Modules/Events/Controllers/EventController.php
@@ -12,6 +12,46 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Traits\ApiResponse;
 
+/**
+ * @OA\Schema(
+ *     schema="EventResource",
+ *     type="object",
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="name", type="string"),
+ *     @OA\Property(property="description", type="string"),
+ *     @OA\Property(property="start_date", type="string", format="date-time"),
+ *     @OA\Property(property="end_date", type="string", format="date-time"),
+ *     @OA\Property(property="location", type="string"),
+ *     @OA\Property(property="coordinador_id", type="integer"),
+ *     @OA\Property(
+ *         property="coordinador",
+ *         type="object",
+ *         @OA\Property(property="id", type="integer"),
+ *         @OA\Property(property="name", type="string")
+ *     )
+ * )
+ * 
+ * @OA\Schema(
+ *     schema="StoreEventRequest",
+ *     required={"name", "start_date", "end_date"},
+ *     @OA\Property(property="name", type="string", maxLength=255),
+ *     @OA\Property(property="description", type="string", nullable=true),
+ *     @OA\Property(property="start_date", type="string", format="date-time"),
+ *     @OA\Property(property="end_date", type="string", format="date-time"),
+ *     @OA\Property(property="location", type="string", maxLength=255, nullable=true),
+ *     @OA\Property(property="coordinador_id", type="integer")
+ * )
+ * 
+ * @OA\Schema(
+ *     schema="UpdateEventRequest",
+ *     @OA\Property(property="name", type="string", maxLength=255),
+ *     @OA\Property(property="description", type="string", nullable=true),
+ *     @OA\Property(property="start_date", type="string", format="date-time"),
+ *     @OA\Property(property="end_date", type="string", format="date-time"),
+ *     @OA\Property(property="location", type="string", maxLength=255, nullable=true),
+ *     @OA\Property(property="coordinador_id", type="integer")
+ * )
+ */
 class EventController extends Controller
 {
     use ApiResponse;
@@ -21,6 +61,53 @@ class EventController extends Controller
     ) {
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/events",
+     *     tags={"Eventos"},
+     *     summary="Obtener listado de eventos",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="fecha_inicio",
+     *         in="query",
+     *         description="Fecha de inicio para filtrar eventos",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="fecha_fin",
+     *         in="query",
+     *         description="Fecha de fin para filtrar eventos",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="coordinador_nombre",
+     *         in="query",
+     *         description="Nombre del coordinador para filtrar eventos",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Listado de eventos obtenido correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Listado de eventos obtenido correctamente"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/EventResource")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function index(ListEventsRequest $request): JsonResponse
     {
         try {
@@ -37,6 +124,40 @@ class EventController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/events",
+     *     tags={"Eventos"},
+     *     summary="Crear un nuevo evento",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/StoreEventRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Evento creado exitosamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Evento creado exitosamente"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/EventResource"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Error de validación",
+     *         @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function store(StoreEventRequest $request): JsonResponse
     {
         try {
@@ -54,6 +175,43 @@ class EventController extends Controller
         }
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/events/{id}",
+     *     tags={"Eventos"},
+     *     summary="Obtener un evento específico",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID del evento",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Evento encontrado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Evento encontrado"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/EventResource"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Evento no encontrado",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function show($id): JsonResponse
     {
         try {
@@ -75,6 +233,52 @@ class EventController extends Controller
         }
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/events/{id}",
+     *     tags={"Eventos"},
+     *     summary="Actualizar un evento existente",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID del evento a actualizar",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/UpdateEventRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Evento actualizado correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Evento actualizado correctamente"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/EventResource"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Evento no encontrado",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Error de validación",
+     *         @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function update(UpdateEventRequest $request, $id): JsonResponse
     {
         try {
@@ -96,6 +300,40 @@ class EventController extends Controller
         }
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/events/{id}",
+     *     tags={"Eventos"},
+     *     summary="Eliminar un evento",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="ID del evento a eliminar",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=204,
+     *         description="Evento eliminado correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Evento eliminado correctamente"),
+     *             @OA\Property(property="data", type="null")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Evento no encontrado",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function destroy($id): JsonResponse
     {
         try {

--- a/app/Modules/Events/Controllers/ProjectEventController.php
+++ b/app/Modules/Events/Controllers/ProjectEventController.php
@@ -9,6 +9,35 @@ use App\Modules\Events\Services\ProjectEventService;
 use Illuminate\Http\JsonResponse;
 use App\Traits\ApiResponse;
 
+/**
+ * @OA\Schema(
+ *     schema="ProjectEventResource",
+ *     type="object",
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="event_id", type="integer"),
+ *     @OA\Property(property="proyecto_id", type="integer"),
+ *     @OA\Property(
+ *         property="proyecto",
+ *         type="object",
+ *         @OA\Property(property="id", type="integer"),
+ *         @OA\Property(property="nombre", type="string")
+ *     ),
+ *     @OA\Property(
+ *         property="evento",
+ *         type="object",
+ *         @OA\Property(property="id", type="integer"),
+ *         @OA\Property(property="nombre", type="string")
+ *     ),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ * 
+ * @OA\Schema(
+ *     schema="ProjectEventRequest",
+ *     required={"proyecto_id"},
+ *     @OA\Property(property="proyecto_id", type="integer")
+ * )
+ */
 class ProjectEventController extends Controller
 {
     use ApiResponse;
@@ -18,6 +47,39 @@ class ProjectEventController extends Controller
     ) {
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/events/{event}/projects",
+     *     tags={"Event Projects"},
+     *     summary="Get all projects for an event",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="event",
+     *         in="path",
+     *         description="ID of the event",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of event projects",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Proyectos del evento obtenidos correctamente"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/ProjectEventResource")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function index(int $eventId): JsonResponse
     {
         $projects = $this->service->getEventProjects($eventId);
@@ -27,6 +89,47 @@ class ProjectEventController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/events/{event}/projects",
+     *     tags={"Event Projects"},
+     *     summary="Add a project to an event",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="event",
+     *         in="path",
+     *         description="ID of the event",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/ProjectEventRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Project added to event successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Proyecto asociado al evento exitosamente"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/ProjectEventResource"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function store(ProjectEventRequest $request, int $eventId): JsonResponse
     {
         $relation = $this->service->addProjectToEvent(
@@ -42,6 +145,50 @@ class ProjectEventController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/events/{event}/projects/{project}",
+     *     tags={"Event Projects"},
+     *     summary="Get project-event relationship details",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="event",
+     *         in="path",
+     *         description="ID of the event",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="project",
+     *         in="path",
+     *         description="ID of the project",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Project-event relationship details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Relación evento-proyecto obtenida"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 ref="#/components/schemas/ProjectEventResource"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Relationship not found",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function show(int $eventId, int $projectId): JsonResponse
     {
         $relation = $this->service->getProjectEventRelation($eventId, $projectId);
@@ -51,6 +198,47 @@ class ProjectEventController extends Controller
         );
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/events/{event}/projects/{project}",
+     *     tags={"Event Projects"},
+     *     summary="Remove a project from an event",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="event",
+     *         in="path",
+     *         description="ID of the event",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="project",
+     *         in="path",
+     *         description="ID of the project",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=204,
+     *         description="Project removed from event successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Proyecto desvinculado del evento correctamente"),
+     *             @OA\Property(property="data", type="null")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Relationship not found",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+     *     )
+     * )
+     */
     public function destroy(int $eventId, int $projectId): JsonResponse
     {
         $this->service->removeProjectFromEvent($eventId, $projectId);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -15,6 +15,429 @@
         }
     ],
     "paths": {
+        "/api/events/{eventId}/activities": {
+            "get": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Get all activities for an event",
+                "operationId": "b415fe0fc8355618241977ff96c0f984",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of activities",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Listado de actividades obtenido correctamente"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/ActivityResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Create a new activity",
+                "operationId": "ed1b0b5d3f114b4ce85327802c8c1584",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreActivityRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Activity created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Actividad creada exitosamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ActivityResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/events/{eventId}/activities/{activityId}": {
+            "get": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Get activity details",
+                "operationId": "ece68efba4b7a1a4058e397d418df745",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "activityId",
+                        "in": "path",
+                        "description": "ID of the activity",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Activity details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Actividad encontrada"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ActivityResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Activity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Update an activity",
+                "operationId": "33a166e0454d8c603a4d0d5f73be6a5e",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "activityId",
+                        "in": "path",
+                        "description": "ID of the activity",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateActivityRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Activity updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Actividad actualizada correctamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ActivityResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Activity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Delete an activity",
+                "operationId": "1abc6be12be265791ffbb3fedd1239e7",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "activityId",
+                        "in": "path",
+                        "description": "ID of the activity",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Activity deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Actividad eliminada correctamente"
+                                        },
+                                        "data": {
+                                            "type": "null"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Activity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/events/{eventId}/activities/{activityId}/assign-responsables": {
+            "post": {
+                "tags": [
+                    "Activities"
+                ],
+                "summary": "Assign responsables to activity",
+                "operationId": "f17d13f5d53c7907cbd8c1b86fa5e3a6",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "activityId",
+                        "in": "path",
+                        "description": "ID of the activity",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AssignResponsablesRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Responsables assigned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Responsables asignados correctamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ActivityResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Activity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/api/auth/register": {
             "post": {
                 "tags": [
@@ -337,9 +760,989 @@
                     }
                 ]
             }
+        },
+        "/api/events": {
+            "get": {
+                "tags": [
+                    "Eventos"
+                ],
+                "summary": "Obtener listado de eventos",
+                "operationId": "40112137de5252277c30d88f9b8149b0",
+                "parameters": [
+                    {
+                        "name": "fecha_inicio",
+                        "in": "query",
+                        "description": "Fecha de inicio para filtrar eventos",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "fecha_fin",
+                        "in": "query",
+                        "description": "Fecha de fin para filtrar eventos",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "coordinador_nombre",
+                        "in": "query",
+                        "description": "Nombre del coordinador para filtrar eventos",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Listado de eventos obtenido correctamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Listado de eventos obtenido correctamente"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/EventResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error del servidor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Eventos"
+                ],
+                "summary": "Crear un nuevo evento",
+                "operationId": "6c217647c212deef37a617ac16d3a066",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreEventRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Evento creado exitosamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Evento creado exitosamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/EventResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Error de validación",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error del servidor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/events/{id}": {
+            "get": {
+                "tags": [
+                    "Eventos"
+                ],
+                "summary": "Obtener un evento específico",
+                "operationId": "450f9f67430128c743509c54ca61d46c",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID del evento",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Evento encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Evento encontrado"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/EventResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Evento no encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error del servidor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Eventos"
+                ],
+                "summary": "Actualizar un evento existente",
+                "operationId": "1c5f708900ed71f683dc3148d9d876a2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID del evento a actualizar",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateEventRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Evento actualizado correctamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Evento actualizado correctamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/EventResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Evento no encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Error de validación",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error del servidor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Eventos"
+                ],
+                "summary": "Eliminar un evento",
+                "operationId": "97408f5e15b53746fa626dab5334821e",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID del evento a eliminar",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Evento eliminado correctamente",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Evento eliminado correctamente"
+                                        },
+                                        "data": {
+                                            "type": "null"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Evento no encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error del servidor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/events/{event}/projects": {
+            "get": {
+                "tags": [
+                    "Event Projects"
+                ],
+                "summary": "Get all projects for an event",
+                "operationId": "019c55c4bb650b5e0a236d7e82902adf",
+                "parameters": [
+                    {
+                        "name": "event",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of event projects",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Proyectos del evento obtenidos correctamente"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/ProjectEventResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Event Projects"
+                ],
+                "summary": "Add a project to an event",
+                "operationId": "226b404d90605091107e67aca5c691ff",
+                "parameters": [
+                    {
+                        "name": "event",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectEventRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Project added to event successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Proyecto asociado al evento exitosamente"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ProjectEventResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/events/{event}/projects/{project}": {
+            "get": {
+                "tags": [
+                    "Event Projects"
+                ],
+                "summary": "Get project-event relationship details",
+                "operationId": "cde39b1b1f3021d7a2058cf6e15a0f22",
+                "parameters": [
+                    {
+                        "name": "event",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "ID of the project",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Project-event relationship details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Relación evento-proyecto obtenida"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/ProjectEventResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Relationship not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Event Projects"
+                ],
+                "summary": "Remove a project from an event",
+                "operationId": "7eb32eb477b0e6639832beb1e24d108c",
+                "parameters": [
+                    {
+                        "name": "event",
+                        "in": "path",
+                        "description": "ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "ID of the project",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Project removed from event successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Proyecto desvinculado del evento correctamente"
+                                        },
+                                        "data": {
+                                            "type": "null"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Relationship not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
         }
     },
     "components": {
+        "schemas": {
+            "ActivityResource": {
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "event_id": {
+                        "type": "integer"
+                    },
+                    "responsables": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "StoreActivityRequest": {
+                "required": [
+                    "name",
+                    "start_date",
+                    "end_date"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateActivityRequest": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "AssignResponsablesRequest": {
+                "required": [
+                    "responsables"
+                ],
+                "properties": {
+                    "responsables": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorResponse": {
+                "properties": {
+                    "status": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Error message"
+                    }
+                },
+                "type": "object"
+            },
+            "ValidationErrorResponse": {
+                "properties": {
+                    "status": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Validation Error"
+                    },
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "EventResource": {
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "coordinador_id": {
+                        "type": "integer"
+                    },
+                    "coordinador": {
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "StoreEventRequest": {
+                "required": [
+                    "name",
+                    "start_date",
+                    "end_date"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "nullable": true
+                    },
+                    "coordinador_id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateEventRequest": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "location": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "nullable": true
+                    },
+                    "coordinador_id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectEventResource": {
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "event_id": {
+                        "type": "integer"
+                    },
+                    "proyecto_id": {
+                        "type": "integer"
+                    },
+                    "proyecto": {
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "nombre": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "evento": {
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "nombre": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectEventRequest": {
+                "required": [
+                    "proyecto_id"
+                ],
+                "properties": {
+                    "proyecto_id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            }
+        },
         "securitySchemes": {
             "bearerAuth": {
                 "type": "http",
@@ -350,8 +1753,20 @@
     },
     "tags": [
         {
+            "name": "Activities",
+            "description": "Endpoints for managing event activities"
+        },
+        {
             "name": "Autenticación",
             "description": "Endpoints para la autenticación de usuarios"
+        },
+        {
+            "name": "Eventos",
+            "description": "Eventos"
+        },
+        {
+            "name": "Event Projects",
+            "description": "Event Projects"
         }
     ]
 }

--- a/tests/Feature/Modules/Events/ActivityModuleTest.php
+++ b/tests/Feature/Modules/Events/ActivityModuleTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Modules\Events;
+
+use App\Modules\Activities\Models\ActivityModel;
+use App\Modules\Events\Models\EventModel;
+use App\Modules\Users\Models\UserModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ActivityModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+    protected $event;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = UserModel::factory()->create();
+        $this->event = EventModel::factory()->create();
+        $this->actingAs($this->user, 'api');
+    }
+
+    /** @test */
+    public function test_can_list_activities_for_an_event()
+    {
+        ActivityModel::factory()->count(2)->create([
+            'evento_id' => $this->event->id
+        ]);
+
+        $response = $this->getJson("/api/events/{$this->event->id}/activities");
+        
+        $response->assertStatus(200)
+                 ->assertJsonCount(2)
+                 ->assertJsonStructure([
+                     '*' => ['id', 'titulo', 'evento_id', 'estado']
+                 ]);
+    }
+
+    /** @test */
+    public function test_can_retrieve_single_activity_for_event()
+    {
+        $activity = ActivityModel::factory()->create([
+            'evento_id' => $this->event->id,
+            'titulo' => 'Actividad Especial'
+        ]);
+
+        $response = $this->getJson("/api/events/{$this->event->id}/activities/{$activity->id}");
+        
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'id' => $activity->id,
+                     'titulo' => 'Actividad Especial'
+                 ]);
+    }
+
+    /** @test */
+    public function test_can_create_activity_within_event()
+    {
+        $payload = [
+            'titulo' => 'Nueva Actividad',
+            'descripcion' => 'Descripción de la actividad',
+            'semillero_id' => 1,
+            'proyecto_id' => 1,
+            'fecha_inicio' => '2024-01-01 10:00:00',
+            'fecha_fin' => '2024-01-01 12:00:00',
+            'estado' => 'pendiente'
+        ];
+
+        $response = $this->postJson("/api/events/{$this->event->id}/activities", $payload);
+        
+        $response->assertStatus(201)
+                 ->assertJsonStructure(['id', 'titulo', 'evento_id'])
+                 ->assertJson(['titulo' => 'Nueva Actividad']);
+        
+        $this->assertDatabaseHas('Actividad', [
+            'titulo' => 'Nueva Actividad',
+            'evento_id' => $this->event->id
+        ]);
+    }
+
+    /** @test */
+    public function test_can_update_activity_details()
+    {
+        $activity = ActivityModel::factory()->create(['evento_id' => $this->event->id]);
+        
+        $updateData = [
+            'titulo' => 'Actividad Actualizada',
+            'estado' => 'completado'
+        ];
+
+        $response = $this->putJson("/api/events/{$this->event->id}/activities/{$activity->id}", $updateData);
+        
+        $response->assertStatus(200)
+                 ->assertJson(['titulo' => 'Actividad Actualizada']);
+        
+        $this->assertDatabaseHas('Actividad', [
+            'id' => $activity->id,
+            'titulo' => 'Actividad Actualizada',
+            'estado' => 'completado'
+        ]);
+    }
+
+    /** @test */
+    public function test_can_remove_activity_from_event()
+    {
+        $activity = ActivityModel::factory()->create(['evento_id' => $this->event->id]);
+        
+        $response = $this->deleteJson("/api/events/{$this->event->id}/activities/{$activity->id}");
+        
+        $response->assertStatus(200)
+                 ->assertJson(['message' => 'Activity deleted successfully']);
+        
+        $this->assertDatabaseMissing('Actividad', ['id' => $activity->id]);
+    }
+}

--- a/tests/Feature/Modules/Events/EventModuleTest.php
+++ b/tests/Feature/Modules/Events/EventModuleTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Modules\Events;
+
+use App\Modules\Events\Models\EventModel;
+use App\Modules\Users\Models\UserModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = UserModel::factory()->create(['role' => 'Coordinador de Eventos']);
+        $this->actingAs($this->user, 'api');
+    }
+
+    /** @test */
+    public function test_can_list_all_events()
+    {
+        EventModel::factory()->count(3)->create();
+        
+        $response = $this->getJson('/api/events');
+        
+        $response->assertStatus(200)
+                 ->assertJsonCount(3)
+                 ->assertJsonStructure([
+                     '*' => ['id', 'nombre', 'descripcion', 'fecha_inicio', 'fecha_fin']
+                 ]);
+    }
+
+    /** @test */
+    public function test_can_retrieve_single_event()
+    {
+        $event = EventModel::factory()->create([
+            'nombre' => 'Evento de Ejemplo'
+        ]);
+
+        $response = $this->getJson("/api/events/{$event->id}");
+        
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'id' => $event->id,
+                     'nombre' => 'Evento de Ejemplo'
+                 ]);
+    }
+
+    /** @test */
+    public function test_can_create_new_event()
+    {
+        $payload = [
+            'nombre' => 'Nuevo Evento',
+            'descripcion' => 'Descripción del evento',
+            'coordinador_id' => $this->user->id,
+            'fecha_inicio' => '2024-01-01 09:00:00',
+            'fecha_fin' => '2024-01-02 18:00:00',
+            'ubicacion' => 'Auditorio Principal'
+        ];
+
+        $response = $this->postJson('/api/events', $payload);
+        
+        $response->assertStatus(201)
+                 ->assertJsonStructure(['id', 'nombre', 'fecha_inicio'])
+                 ->assertJson(['nombre' => 'Nuevo Evento']);
+        
+        $this->assertDatabaseHas('Evento', ['nombre' => 'Nuevo Evento']);
+    }
+
+    /** @test */
+    public function test_can_update_existing_event()
+    {
+        $event = EventModel::factory()->create();
+        
+        $updateData = [
+            'nombre' => 'Evento Actualizado',
+            'descripcion' => 'Nueva descripción'
+        ];
+
+        $response = $this->putJson("/api/events/{$event->id}", $updateData);
+        
+        $response->assertStatus(200)
+                 ->assertJson(['nombre' => 'Evento Actualizado']);
+        
+        $this->assertDatabaseHas('Evento', [
+            'id' => $event->id,
+            'nombre' => 'Evento Actualizado'
+        ]);
+    }
+
+    /** @test */
+    public function test_can_delete_event()
+    {
+        $event = EventModel::factory()->create();
+        
+        $response = $this->deleteJson("/api/events/{$event->id}");
+        
+        $response->assertStatus(200)
+                 ->assertJson(['message' => 'Event deleted successfully']);
+        
+        $this->assertDatabaseMissing('Evento', ['id' => $event->id]);
+    }
+}


### PR DESCRIPTION
This pull request introduces extensive OpenAPI documentation for the `ActivityController` and `EventController` classes, enhancing the API's clarity and usability. The changes include defining schemas for request and response payloads, and documenting endpoints for CRUD operations and specific actions like assigning responsables to activities.

### OpenAPI Documentation for `ActivityController`:

* **Schemas Added:**
  - Defined schemas such as `ActivityResource`, `StoreActivityRequest`, `UpdateActivityRequest`, `AssignResponsablesRequest`, `ErrorResponse`, and `ValidationErrorResponse` to standardize request and response formats.

* **Endpoints Documented:**
  - [`index`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR137-R172): Fetch all activities for a specific event.
  - [`store`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR187-R225): Create a new activity under an event.
  - [`show`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR239-R286): Retrieve details of a specific activity.
  - [`update`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR300-R342): Update an existing activity.
  - [`assignResponsables`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR356-R391): Assign responsables to an activity.
  - [`destroy`](diffhunk://#diff-8f26b30fff2d9b04fc12eca20c3b0e1a6a26cce08e775b72129a7f1c956187dfR356-R391): Delete an activity.

### OpenAPI Documentation for `EventController`:

* **Schemas Added:**
  - Defined schemas such as `EventResource`, `StoreEventRequest`, `UpdateEventRequest`, and reused common error schemas.

* **Endpoints Documented:**
  - [`index`](diffhunk://#diff-b4a3d3f85c6dba07fcd3154bc66bfb2a321e13ab8708f8871abace97a012d1cdR64-R110): Retrieve a list of events with optional filters.
  - [`store`](diffhunk://#diff-b4a3d3f85c6dba07fcd3154bc66bfb2a321e13ab8708f8871abace97a012d1cdR127-R160): Create a new event.
  - [`show`](diffhunk://#diff-b4a3d3f85c6dba07fcd3154bc66bfb2a321e13ab8708f8871abace97a012d1cdR178-R214): Fetch details of a specific event.
  - [`update`](diffhunk://#diff-b4a3d3f85c6dba07fcd3154bc66bfb2a321e13ab8708f8871abace97a012d1cdR236-R281): Update an existing event.
  - [`destroy`](diffhunk://#diff-b4a3d3f85c6dba07fcd3154bc66bfb2a321e13ab8708f8871abace97a012d1cdR303-R336): Delete an event.