### PR TITLE
Feature/university management

### DIFF
--- a/app/Modules/Universities/Controllers/UniversityController.php
+++ b/app/Modules/Universities/Controllers/UniversityController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Modules\Universities\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Universities\Services\UniversityService;
+use App\Traits\ApiResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class UniversityController extends Controller
+{
+    use ApiResponse;
+
+    public function __construct(protected UniversityService $universityService)
+    {
+    }
+
+    public function index()
+    {
+        try {
+            $universities = $this->universityService->getAll();
+            return $this->successResponse($universities, 'Universidades obtenidas correctamente');
+        } catch (\Exception $e) {
+            return $this->errorResponse($e->getMessage(), 500);
+        }
+    }
+
+    public function show($id)
+    {
+        try {
+            $university = $this->universityService->getById($id);
+            return $this->successResponse($university, 'Universidad obtenida correctamente');
+        } catch (\Exception $e) {
+            return $this->errorResponse($e->getMessage(), 404);
+        }
+    }
+
+    public function store(Request $request)
+    {
+        try {
+            $validatedData = $request->validate([
+                'nombre' => 'required|string|max:255',
+            ]);
+            $university = $this->universityService->create($validatedData);
+            return $this->successResponse($university, 'Universidad creada correctamente', 201);
+        } catch (ValidationException $e) {
+            return $this->errorResponse('Errores de validación', 422, $e->errors());
+        } catch (\Exception $e) {
+            return $this->errorResponse('No se pudo crear la universidad: ' . $e->getMessage(), 500);
+        }
+    }
+
+    public function update(Request $request, $id)
+    {
+        try {
+            $validatedData = $request->validate([
+                'nombre' => 'required|string|max:255',
+            ]);
+            $university = $this->universityService->update($id, $validatedData);
+            return $this->successResponse($university, 'Universidad actualizada correctamente');
+        } catch (ValidationException $e) {
+            return $this->errorResponse('Errores de validación', 422, $e->errors());
+        } catch (\Exception $e) {
+            return $this->errorResponse($e->getMessage(), 404);
+        }
+    }
+
+    public function destroy($id)
+    {
+        try {
+            $this->universityService->delete($id);
+            return $this->successResponse(null, 'Universidad eliminada correctamente');
+        } catch (\Exception $e) {
+            return $this->errorResponse($e->getMessage(), 404);
+        }
+    }
+}

--- a/app/Modules/Universities/Controllers/UniversityController.php
+++ b/app/Modules/Universities/Controllers/UniversityController.php
@@ -8,6 +8,13 @@ use App\Traits\ApiResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 
+
+/**
+ * @OA\Tag(
+ *     name="Universidades",
+ *     description="Operaciones relacionadas con universidades"
+ * )
+ */
 class UniversityController extends Controller
 {
     use ApiResponse;
@@ -16,6 +23,54 @@ class UniversityController extends Controller
     {
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/universities",
+     *     summary="Obtener todas las universidades",
+     *     description="Devuelve una lista de todas las universidades registradas.",
+     *     operationId="getAllUniversities",
+     *     tags={"Universidades"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de universidades obtenida correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="nombre", type="string", example="Universidad Ejemplo"),
+     *                 @OA\Property(property="fecha_creacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z"),
+     *                 @OA\Property(property="fecha_actualizacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z")
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Universidades obtenidas correctamente"),
+     *             @OA\Property(property="status", type="integer", example=200)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="No autenticado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No autenticado"),
+     *             @OA\Property(property="status", type="integer", example=401)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Acceso denegado (rol no autorizado)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No tienes permisos para realizar esta acción"),
+     *             @OA\Property(property="status", type="integer", example=403)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No se encontraron universidades inscritas"),
+     *             @OA\Property(property="status", type="integer", example=500)
+     *         )
+     *     )
+     * )
+     */
     public function index()
     {
         try {
@@ -26,6 +81,61 @@ class UniversityController extends Controller
         }
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/universities/{university}",
+     *     summary="Obtener una universidad por ID",
+     *     description="Devuelve los detalles de una universidad específica.",
+     *     operationId="getUniversityById",
+     *     tags={"Universidades"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Parameter(
+     *         name="university",
+     *         in="path",
+     *         description="ID de la universidad",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Universidad obtenida correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="nombre", type="string", example="Universidad Ejemplo"),
+     *                 @OA\Property(property="fecha_creacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z"),
+     *                 @OA\Property(property="fecha_actualizacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Universidad obtenida correctamente"),
+     *             @OA\Property(property="status", type="integer", example=200)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="No autenticado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No autenticado"),
+     *             @OA\Property(property="status", type="integer", example=401)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Acceso denegado (rol no autorizado)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No tienes permisos para realizar esta acción"),
+     *             @OA\Property(property="status", type="integer", example=403)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Universidad no encontrada",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No se encontró la universidad con ID: 1"),
+     *             @OA\Property(property="status", type="integer", example=404)
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         try {
@@ -36,6 +146,73 @@ class UniversityController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/universities",
+     *     summary="Crear una nueva universidad",
+     *     description="Crea una nueva universidad con el nombre proporcionado.",
+     *     operationId="createUniversity",
+     *     tags={"Universidades"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="Datos de la universidad",
+     *         @OA\JsonContent(
+     *             required={"nombre"},
+     *             @OA\Property(property="nombre", type="string", maxLength=255, example="Universidad Ejemplo", description="Nombre de la universidad")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Universidad creada correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="nombre", type="string", example="Universidad Ejemplo"),
+     *                 @OA\Property(property="fecha_creacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z"),
+     *                 @OA\Property(property="fecha_actualizacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Universidad creada correctamente"),
+     *             @OA\Property(property="status", type="integer", example=201)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="No autenticado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No autenticado"),
+     *             @OA\Property(property="status", type="integer", example=401)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Acceso denegado (rol no autorizado)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No tienes permisos para realizar esta acción"),
+     *             @OA\Property(property="status", type="integer", example=403)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Errores de validación",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Errores de validación"),
+     *             @OA\Property(property="errors", type="object",
+     *                 @OA\Property(property="nombre", type="array", @OA\Items(type="string", example="El campo nombre es obligatorio"))
+     *             ),
+     *             @OA\Property(property="status", type="integer", example=422)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Error del servidor",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No se pudo crear la universidad: Error de base de datos"),
+     *             @OA\Property(property="status", type="integer", example=500)
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         try {
@@ -51,6 +228,80 @@ class UniversityController extends Controller
         }
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/universities/{university}",
+     *     summary="Actualizar una universidad",
+     *     description="Actualiza el nombre de una universidad existente.",
+     *     operationId="updateUniversity",
+     *     tags={"Universidades"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Parameter(
+     *         name="university",
+     *         in="path",
+     *         description="ID de la universidad",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         description="Datos actualizados de la universidad",
+     *         @OA\JsonContent(
+     *             required={"nombre"},
+     *             @OA\Property(property="nombre", type="string", maxLength=255, example="Universidad Actualizada", description="Nuevo nombre de la universidad")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Universidad actualizada correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="nombre", type="string", example="Universidad Actualizada"),
+     *                 @OA\Property(property="fecha_creacion", type="string", format="date-time", example="2025-05-16T09:50:00.000000Z"),
+     *                 @OA\Property(property="fecha_actualizacion", type="string", format="date-time", example="2025-05-16T10:00:00.000000Z")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Universidad actualizada correctamente"),
+     *             @OA\Property(property="status", type="integer", example=200)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="No autenticado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No autenticado"),
+     *             @OA\Property(property="status", type="integer", example=401)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Acceso denegado (rol no autorizado)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No tienes permisos para realizar esta acción"),
+     *             @OA\Property(property="status", type="integer", example=403)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Universidad no encontrada",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No se encontró la universidad con ID: 1"),
+     *             @OA\Property(property="status", type="integer", example=404)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Errores de validación",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Errores de validación"),
+     *             @OA\Property(property="errors", type="object",
+     *                 @OA\Property(property="nombre", type="array", @OA\Items(type="string", example="El campo nombre es obligatorio"))
+     *             ),
+     *             @OA\Property(property="status", type="integer", example=422)
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         try {
@@ -66,6 +317,56 @@ class UniversityController extends Controller
         }
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/universities/{university}",
+     *     summary="Eliminar una universidad",
+     *     description="Elimina una universidad existente por su ID.",
+     *     operationId="deleteUniversity",
+     *     tags={"Universidades"},
+     *     security={{"bearerAuth": {}}},
+     *     @OA\Parameter(
+     *         name="university",
+     *         in="path",
+     *         description="ID de la universidad",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Universidad eliminada correctamente",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="null"),
+     *             @OA\Property(property="message", type="string", example="Universidad eliminada correctamente"),
+     *             @OA\Property(property="status", type="integer", example=200)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="No autenticado",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No autenticado"),
+     *             @OA\Property(property="status", type="integer", example=401)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Acceso denegado (rol no autorizado)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No tienes permisos para realizar esta acción"),
+     *             @OA\Property(property="status", type="integer", example=403)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Universidad no encontrada",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No se encontró la universidad con ID: 1"),
+     *             @OA\Property(property="status", type="integer", example=404)
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         try {

--- a/app/Modules/Universities/Models/UniversityModel.php
+++ b/app/Modules/Universities/Models/UniversityModel.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Universities\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UniversityModel extends Model
+{
+    protected $table = 'Universidad';
+    protected $primaryKey = 'id';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'nombre',
+        'fecha_creacion',
+        'fecha_actualizacion',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'nombre' => 'string',
+        'fecha_creacion' => 'datetime',
+        'fecha_actualizacion' => 'datetime',
+    ];
+
+    public function faculties(): HasMany
+    {
+        return $this->hasMany(\App\Modules\Faculties\Models\FacultyModel::class, 'universidad_id', 'id');
+    }
+}

--- a/app/Modules/Universities/Repositories/UniversityRepository.php
+++ b/app/Modules/Universities/Repositories/UniversityRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Modules\Universities\Repositories;
+
+use App\Modules\Universities\Models\UniversityModel;
+
+class UniversityRepository
+{
+    public function getAll()
+    {
+        return UniversityModel::all();
+    }
+
+    public function getById($id)
+    {
+        return UniversityModel::findOrFail($id);
+    }
+
+    public function create(array $data)
+    {
+        return UniversityModel::create($data);
+    }
+
+    public function update($id, array $data)
+    {
+        $university = UniversityModel::find($id);
+        if ($university) {
+            $university->update($data);
+            return $university;
+        }
+        return null;
+    }
+
+    public function delete($id)
+    {
+        $university = UniversityModel::find($id);
+        if ($university) {
+            $university->delete();
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/Modules/Universities/Services/UniversityService.php
+++ b/app/Modules/Universities/Services/UniversityService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Modules\Universities\Services;
+
+use App\Modules\Universities\Repositories\UniversityRepository;
+
+class UniversityService
+{
+    public function __construct(protected UniversityRepository $universityRepository)
+    {
+    }
+
+    public function getAll()
+    {
+        try {
+            $universities = $this->universityRepository->getAll();
+
+            if ($universities->isEmpty()) {
+                throw new \Exception('No se encontraron universidades inscritas');
+            }
+
+            return $universities;
+        } catch (\Exception $e) {
+            throw new \Exception('Error al obtener las universidades: ' . $e->getMessage());
+        }
+    }
+
+    public function getById($id)
+    {
+        try {
+            return $this->universityRepository->getById($id);
+        } catch (\Exception $e) {
+            throw new \Exception("No se encontró la universidad con ID: {$id}");
+        }
+    }
+
+    public function create(array $data)
+    {
+        try {
+            return $this->universityRepository->create($data);
+        } catch (\Exception $e) {
+            throw new \Exception('No se pudo crear la universidad: ' . $e->getMessage());
+        }
+    }
+
+    public function update($id, array $data)
+    {
+        try {
+            $university = $this->universityRepository->update($id, $data);
+
+            if (!$university) {
+                throw new \Exception("No se encontró la universidad con ID: {$id} para actualizar");
+            }
+
+            return $university;
+        } catch (\Exception $e) {
+            throw new \Exception("Error al actualizar la universidad con ID: {$id}: " . $e->getMessage());
+        }
+    }
+
+    public function delete($id)
+    {
+        try {
+            $deleted = $this->universityRepository->delete($id);
+
+            if (!$deleted) {
+                throw new \Exception("No se encontró la universidad con ID: {$id} para eliminar");
+            }
+
+            return true;
+        } catch (\Exception $e) {
+            throw new \Exception("Error al eliminar la universidad con ID: {$id}: " . $e->getMessage());
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Modules\Activities\Controllers\ActivityController;
 use App\Modules\Events\Controllers\EventController;
 use App\Modules\Events\Controllers\ProjectEventController;
+use App\Modules\Universities\Controllers\UniversityController;
 use Illuminate\Support\Facades\Route;
 use App\Modules\Authentication\Controllers\AuthController;
 
@@ -37,10 +38,19 @@ Route::prefix('events')->middleware(['auth:api', 'roles:Coordinador de Eventos']
     });
 
     Route::prefix('{event}/projects')->group(function () {
-        Route::get('/', [ProjectEventController::class, 'index']); 
+        Route::get('/', [ProjectEventController::class, 'index']);
         Route::post('/', [ProjectEventController::class, 'store']);
         Route::get('/{project}', [ProjectEventController::class, 'show']);
         Route::delete('/{project}', [ProjectEventController::class, 'destroy']);
     });
 
+});
+
+
+Route::prefix('universities')->middleware(['auth:api', 'roles:Administrador'])->group(function () {
+    Route::get('/', [UniversityController::class, 'index']);
+    Route::post('/', [UniversityController::class, 'store']);
+    Route::get('/{university}', [UniversityController::class, 'show']);
+    Route::put('/{university}', [UniversityController::class, 'update']);
+    Route::delete('/{university}', [UniversityController::class, 'destroy']);
 });


### PR DESCRIPTION
This pull request introduces a new module for managing universities, including a controller, model, repository, service, and API routes. The changes implement CRUD operations and integrate OpenAPI documentation for the endpoints.

### New Module: Universities

#### Controller and API Endpoints:
* Added `UniversityController` to handle CRUD operations for universities. The controller includes methods for listing, creating, updating, retrieving, and deleting universities, with detailed OpenAPI documentation for each endpoint.
* Defined API routes in `routes/api.php` under the `/universities` prefix, protected by authentication and role-based middleware. [[1]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR48-R56) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR6)

#### Model:
* Created `UniversityModel` to represent the `Universidad` table, with fields for `id`, `nombre`, `fecha_creacion`, and `fecha_actualizacion`. Includes a relationship to faculties via the `faculties` method.

#### Repository:
* Added `UniversityRepository` to encapsulate database interactions for universities, including methods for fetching, creating, updating, and deleting records.

#### Service:
* Implemented `UniversityService` to handle business logic for university operations, including error handling for cases like missing records or validation failures.